### PR TITLE
Run s3.yml through erb for ENV variables

### DIFF
--- a/lib/redmine_s3/connection.rb
+++ b/lib/redmine_s3/connection.rb
@@ -14,7 +14,8 @@ module RedmineS3
     
     class << self
       def load_options
-        YAML::load( File.open(File.join(Rails.root, 'config', 's3.yml')) )[Rails.env].each do |key, value|
+        file = ERB.new( File.read(File.join(Rails.root, 'config', 's3.yml')) ).result
+        YAML::load( file )[Rails.env].each do |key, value|
          @@s3_options[key.to_sym] = value
         end
       end


### PR DESCRIPTION
This allows you to define your s3 credentials using ERB and Heroku's config variables, so that you're not checking sensitive data into source control.

For example, using this fork, my s3.yml file looks like this:

```
production:
  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
  bucket: <%= ENV['S3_BUCKET'] %>
  endpoint:
  secure: true
  private: 
  expires: 

```

This should be backwards compatible with the existing s3.yml direct format since ERB would simply not find any erb to parse out.
